### PR TITLE
Add unit tests for GameScheduleController, GameScheduleServiceImpl an…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,20 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<!-- Test cases -->
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.13.1</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>3.12.4</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/task/wealthpilot/firstleague/service/impl/GameScheduleMultipleMatchesServiceImpl.java
+++ b/src/main/java/com/task/wealthpilot/firstleague/service/impl/GameScheduleMultipleMatchesServiceImpl.java
@@ -20,7 +20,7 @@ import java.util.List;
 @Slf4j
 public class GameScheduleMultipleMatchesServiceImpl implements GameScheduleMultipleMatchesService {
     @Value("${league.start.date}")
-    private String leagueStartDate;
+    String leagueStartDate;
     private final GameScheduleMapper gameScheduleMapper;
     private final List<String> schedule;
 

--- a/src/main/java/com/task/wealthpilot/firstleague/service/impl/GameScheduleServiceImpl.java
+++ b/src/main/java/com/task/wealthpilot/firstleague/service/impl/GameScheduleServiceImpl.java
@@ -23,7 +23,7 @@ public class GameScheduleServiceImpl implements GameScheduleService {
     private final List<String> schedule;
 
     @Value("${league.start.date}")
-    private String leagueStartDate;
+    String leagueStartDate;
 
     @Override
     public LeagueResponse generateSchedule(List<Team> teams) {

--- a/src/main/java/com/task/wealthpilot/firstleague/service/mapper/GameScheduleMapper.java
+++ b/src/main/java/com/task/wealthpilot/firstleague/service/mapper/GameScheduleMapper.java
@@ -10,6 +10,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.IntUnaryOperator;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 @Component
 public class GameScheduleMapper {
@@ -19,7 +21,7 @@ public class GameScheduleMapper {
     @Value("${league.matches.per.saturday}")
     private int league_matches;
 
-    private AtomicInteger index = new AtomicInteger(1);
+    private final AtomicInteger index = new AtomicInteger(1);
 
     public IntUnaryOperator calculateStartDate = (currentIndex) -> {
         if (currentIndex == league_matches) {
@@ -32,12 +34,11 @@ public class GameScheduleMapper {
     };
 
     public List<String> generateMatches(List<Team> teams) {
-        List<String> matches = new ArrayList<>();
-        for (int i = 0; i < teams.size(); i++) {
-            for (int j = i + 1; j < teams.size(); j++) {
-                matches.add(teams.get(i).getName() + " vs " + teams.get(j).getName());
-            }
-        }
+        List<String> matches = IntStream.range(0, teams.size())
+                .boxed()
+                .flatMap(i -> IntStream.range(i + 1, teams.size())
+                        .mapToObj(j -> teams.get(i).getName() + " vs " + teams.get(j).getName()))
+                .collect(Collectors.toList());
         Collections.shuffle(matches); // Shuffle matches for randomness
         return matches;
     }

--- a/src/test/java/com/task/wealthpilot/firstleague/controller/GameScheduleControllerTest.java
+++ b/src/test/java/com/task/wealthpilot/firstleague/controller/GameScheduleControllerTest.java
@@ -1,0 +1,58 @@
+package com.task.wealthpilot.firstleague.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.task.wealthpilot.firstleague.model.LeagueRequest;
+import com.task.wealthpilot.firstleague.model.Team;
+import org.junit.Before;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.util.Arrays;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc
+@SpringBootTest
+public class GameScheduleControllerTest {
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    public void generateScheduleTest() throws Exception {
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/generate-schedule")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(leagueRequest()))
+        ).andExpect(status().isCreated());
+    }
+
+    private LeagueRequest leagueRequest() {
+        return LeagueRequest.builder()
+                .league("Wealthpilot first league")
+                .country("Germany")
+                .teams(Arrays.asList(
+                        Team.builder().name("Volksbank Kickers").foundingDate("1998").build(),
+                        Team.builder().name("Arminia Sparkasse").foundingDate("2000").build(),
+                        Team.builder().name("DJ FC").build(),
+                        Team.builder().name("1. FC Marco").build(),
+                        Team.builder().name("Borussia Helvetia").foundingDate("2001").build(),
+                        Team.builder().name("SC Graz").build()
+                ))
+                .build();
+    }
+}

--- a/src/test/java/com/task/wealthpilot/firstleague/controller/GameScheduleMultipleMatchesControllerTest.java
+++ b/src/test/java/com/task/wealthpilot/firstleague/controller/GameScheduleMultipleMatchesControllerTest.java
@@ -1,0 +1,58 @@
+package com.task.wealthpilot.firstleague.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.task.wealthpilot.firstleague.model.LeagueRequest;
+import com.task.wealthpilot.firstleague.model.Team;
+import org.junit.Before;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.util.Arrays;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc
+@SpringBootTest
+public class GameScheduleMultipleMatchesControllerTest {
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    public void testGenerateScheduleTes() throws Exception {
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/generate-schedule-multiple")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(leagueRequest()))
+        ).andExpect(status().isCreated());
+    }
+
+    private LeagueRequest leagueRequest() {
+        return LeagueRequest.builder()
+                .league("Wealthpilot first league")
+                .country("Germany")
+                .teams(Arrays.asList(
+                        Team.builder().name("Volksbank Kickers").foundingDate("1998").build(),
+                        Team.builder().name("Arminia Sparkasse").foundingDate("2000").build(),
+                        Team.builder().name("DJ FC").build(),
+                        Team.builder().name("1. FC Marco").build(),
+                        Team.builder().name("Borussia Helvetia").foundingDate("2001").build(),
+                        Team.builder().name("SC Graz").build()
+                ))
+                .build();
+    }
+}

--- a/src/test/java/com/task/wealthpilot/firstleague/service/impl/GameScheduleMultipleMatchesServiceImplTest.java
+++ b/src/test/java/com/task/wealthpilot/firstleague/service/impl/GameScheduleMultipleMatchesServiceImplTest.java
@@ -1,0 +1,117 @@
+package com.task.wealthpilot.firstleague.service.impl;
+
+import com.task.wealthpilot.firstleague.model.LeagueRequest;
+import com.task.wealthpilot.firstleague.model.LeagueResponse;
+import com.task.wealthpilot.firstleague.model.Team;
+import com.task.wealthpilot.firstleague.service.exception.GameScheduleServiceException;
+import com.task.wealthpilot.firstleague.service.mapper.GameScheduleMapper;
+import com.task.wealthpilot.firstleague.utils.DateUtil;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+@RunWith(SpringRunner.class)
+@TestPropertySource(locations = "classpath:application-test.properties")
+public class GameScheduleMultipleMatchesServiceImplTest {
+
+    @Value("${league.start.date}")
+    private String leagueStartDate;
+    @Mock
+    private GameScheduleMapper gameScheduleMapper;
+
+    @InjectMocks
+    private GameScheduleMultipleMatchesServiceImpl gameScheduleService;
+
+    private List<String> schedule;
+
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        schedule = new ArrayList<>();
+        gameScheduleService = new GameScheduleMultipleMatchesServiceImpl(gameScheduleMapper, schedule);
+        gameScheduleService.leagueStartDate = leagueStartDate;
+    }
+
+    @Test
+    public void testGenerateScheduleMultipleMatchesPerWeek() {
+        var teams = leagueRequest().getTeams();
+
+        List<String> firstLegMatches = new ArrayList<>();
+        firstLegMatches.add("DJ FC vs SC Graz");
+        firstLegMatches.add("Volksbank Kickers vs Arminia Sparkasse");
+        firstLegMatches.add("1. FC Marco vs Borussia Helvetia");
+        firstLegMatches.add("Borussia Helvetia vs SC Graz");
+
+        List<String> secondLegMatches = new ArrayList<>();
+        secondLegMatches.add("DJ FC vs 1. FC Marco");
+        secondLegMatches.add("Arminia Sparkasse vs 1. FC Marco");
+        secondLegMatches.add("Borussia Helvetia vs DJ FC");
+        secondLegMatches.add("Arminia Sparkasse vs Volksbank Kickers");
+
+
+        when(gameScheduleMapper.generateMatches(teams)).thenReturn(firstLegMatches);
+        when(gameScheduleMapper.generateReverseFixtures(firstLegMatches)).thenReturn(secondLegMatches);
+        when(gameScheduleMapper.breakWeeks(any())).thenAnswer(invocation -> invocation.getArgument(0, LocalDate.class).plusWeeks(3));
+        when(gameScheduleMapper.calculateNewStartDate()).thenReturn(1);
+
+        LeagueResponse response = gameScheduleService.generateScheduleMultipleMatchesPerWeek(teams);
+
+        verify(gameScheduleMapper, times(1)).generateMatches(teams);
+        verify(gameScheduleMapper, times(1)).generateReverseFixtures(firstLegMatches);
+        verify(gameScheduleMapper, times(1)).breakWeeks(any(LocalDate.class));
+        verify(gameScheduleMapper, times(8)).calculateNewStartDate();
+
+        List<String> expectedSchedule = new ArrayList<>();
+        LocalDate startDate = LocalDate.parse(leagueStartDate).with(java.time.DayOfWeek.SATURDAY);
+        for (String match : firstLegMatches) {
+            expectedSchedule.add(DateUtil.formatDate(startDate) + " " + match);
+            startDate = startDate.plusWeeks(1);
+        }
+        startDate = startDate.plusWeeks(3);  // Adding break between legs
+        for (String match : secondLegMatches) {
+            expectedSchedule.add(DateUtil.formatDate(startDate) + " " + match);
+            startDate = startDate.plusWeeks(1);
+        }
+
+        assertEquals(expectedSchedule, response.getLeagueSchedule());
+    }
+
+    private LeagueRequest leagueRequest() {
+        return LeagueRequest.builder()
+                .league("Wealthpilot first league")
+                .country("Germany")
+                .teams(Arrays.asList(
+                        Team.builder().name("Volksbank Kickers").foundingDate("1998").build(),
+                        Team.builder().name("Arminia Sparkasse").foundingDate("2000").build(),
+                        Team.builder().name("DJ FC").build(),
+                        Team.builder().name("1. FC Marco").build(),
+                        Team.builder().name("Borussia Helvetia").foundingDate("2001").build(),
+                        Team.builder().name("SC Graz").build()
+                ))
+                .build();
+    }
+
+    @Test(expected = GameScheduleServiceException.class)
+    public void testGenerateScheduleMultipleMatchesPerWeek_Exception() {
+        List<Team> teams = new ArrayList<>();
+        when(gameScheduleMapper.generateMatches(teams)).thenThrow(new RuntimeException());
+
+        gameScheduleService.generateScheduleMultipleMatchesPerWeek(teams);
+    }
+}
+

--- a/src/test/java/com/task/wealthpilot/firstleague/service/impl/GameScheduleServiceImplTest.java
+++ b/src/test/java/com/task/wealthpilot/firstleague/service/impl/GameScheduleServiceImplTest.java
@@ -1,0 +1,108 @@
+package com.task.wealthpilot.firstleague.service.impl;
+
+import com.task.wealthpilot.firstleague.model.LeagueRequest;
+import com.task.wealthpilot.firstleague.model.LeagueResponse;
+import com.task.wealthpilot.firstleague.model.Team;
+import com.task.wealthpilot.firstleague.service.exception.GameScheduleServiceException;
+import com.task.wealthpilot.firstleague.service.mapper.GameScheduleMapper;
+import com.task.wealthpilot.firstleague.utils.DateUtil;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+@RunWith(SpringRunner.class)
+@TestPropertySource(locations = "classpath:application-test.properties")
+public class GameScheduleServiceImplTest {
+
+    @Mock
+    private GameScheduleMapper gameScheduleMapper;
+
+    @InjectMocks
+    private GameScheduleServiceImpl gameScheduleService;
+
+    @Value("${league.start.date}")
+    private String leagueStartDate;
+
+    private List<String> schedule;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        schedule = new ArrayList<>();
+        gameScheduleService = new GameScheduleServiceImpl(gameScheduleMapper, schedule);
+        gameScheduleService.leagueStartDate = leagueStartDate;
+    }
+
+    @Test
+    public void testGenerateSchedule() {
+        var teams = leagueRequest().getTeams();
+
+        List<String> firstLegMatches = new ArrayList<>();
+        firstLegMatches.add("05.10.2019 DJ FC vs SC Graz");
+        firstLegMatches.add("12.10.2019 1. FC Marco vs Borussia Helvetia");
+
+        List<String> secondLegMatches = new ArrayList<>();
+        secondLegMatches.add("04.01.2020 1. FC Marco vs Arminia Sparkasse");
+        secondLegMatches.add("11.01.2020 Borussia Helvetia vs DJ FC");
+
+        when(gameScheduleMapper.generateMatches(teams)).thenReturn(firstLegMatches);
+        when(gameScheduleMapper.generateReverseFixtures(firstLegMatches)).thenReturn(secondLegMatches);
+        when(gameScheduleMapper.breakWeeks(any())).thenAnswer(invocation -> invocation.getArgument(0, LocalDate.class).plusWeeks(3));
+
+        LeagueResponse response = gameScheduleService.generateSchedule(teams);
+
+        verify(gameScheduleMapper, times(1)).generateMatches(teams);
+        verify(gameScheduleMapper, times(1)).generateReverseFixtures(firstLegMatches);
+        verify(gameScheduleMapper, times(1)).breakWeeks(any(LocalDate.class));
+
+        List<String> expectedSchedule = new ArrayList<>();
+        LocalDate startDate = LocalDate.parse(leagueStartDate).with(java.time.DayOfWeek.SATURDAY);
+        for (String match : firstLegMatches) {
+            expectedSchedule.add(DateUtil.formatDate(startDate) + " " + match);
+            startDate = startDate.plusWeeks(1);
+        }
+        startDate = startDate.plusWeeks(3);  // Adding break between legs
+        for (String match : secondLegMatches) {
+            expectedSchedule.add(DateUtil.formatDate(startDate) + " " + match);
+            startDate = startDate.plusWeeks(1);
+        }
+
+        assertEquals(expectedSchedule, response.getLeagueSchedule());
+    }
+
+    @Test(expected = GameScheduleServiceException.class)
+    public void testGenerateSchedule_Exception() {
+        List<Team> teams = new ArrayList<>();
+        when(gameScheduleMapper.generateMatches(teams)).thenThrow(new RuntimeException());
+
+        gameScheduleService.generateSchedule(teams);
+    }
+
+    private LeagueRequest leagueRequest() {
+        return LeagueRequest.builder()
+                .league("Wealthpilot first league")
+                .country("Germany")
+                .teams(Arrays.asList(
+                        Team.builder().name("Volksbank Kickers").foundingDate("1998").build(),
+                        Team.builder().name("Arminia Sparkasse").foundingDate("2000").build(),
+                        Team.builder().name("DJ FC").build(),
+                        Team.builder().name("1. FC Marco").build(),
+                        Team.builder().name("Borussia Helvetia").foundingDate("2001").build(),
+                        Team.builder().name("SC Graz").build()
+                ))
+                .build();
+    }
+}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,1 @@
+league.start.date=2019-10-03


### PR DESCRIPTION
…d GameScheduleMultipleMatchesController, GameScheduleMultipleMatchesServiceImpl

- Implement unit tests for GameScheduleController
  - Test generateSchedule method for POST operation
- Implement unit tests for GameScheduleServiceImpl
  - Test generateSchedule method for normal operation
  - Test exception handling in generateSchedule method
- Implement unit tests for GameScheduleMultipleMatchesController
  - Test generateScheduleMultipleMatchesPerWeek method for POST operation
- Implement unit tests for GameScheduleMultipleMatchesServiceImpl
  - Test generateScheduleMultipleMatchesPerWeek method for normal operation
  - Test exception handling in generateScheduleMultipleMatchesPerWeek method
- Ensure proper mocking of dependencies
- Validate expected schedules against actual generated schedules
- Modified ServiceMapper with IntStream