### PR TITLE
Integrate OpenAPI/Swagger for API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ This Spring Boot application generates a game schedule for a soccer league. The 
     POST /api/generate-schedule-multiple
     ```
 
+- **Swagger:**
+
+  ```
+  http://{localhost:8080}/swagger-ui/index.html
+  ```
+
+- **OpenAPI:**
+
+  ```
+  http://{localhost:8080}/api-docs
+  ```
+
 ## Example JSON Format
 
 The JSON file `soccer_teams.json` should have the following format:

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,18 @@
 			<version>3.12.4</version>
 			<scope>test</scope>
 		</dependency>
+
+		<!-- Springdoc OpenAPI for Spring Boot -->
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.5.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-api</artifactId>
+			<version>2.5.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/task/wealthpilot/firstleague/config/OpenAPIConfig.java
+++ b/src/main/java/com/task/wealthpilot/firstleague/config/OpenAPIConfig.java
@@ -1,0 +1,33 @@
+package com.task.wealthpilot.firstleague.config;
+
+import io.swagger.v3.oas.models.ExternalDocumentation;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenAPIConfig {
+
+    @Bean
+    public OpenAPI productServiceAPI() {
+
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Wealthpilot First League API")
+                        .description("API for generating game schedules for the Wealthpilot First League")
+                        .version("1.0.0")
+                        .contact(new Contact()
+                                .name("Support Team")
+                                .email("support@wealthpilot.com")
+                                .url("https://www.wealthpilot.com"))
+                        .license(new License()
+                                .name("Apache 2.0")
+                                .url("http://springdoc.org")))
+                .externalDocs(new ExternalDocumentation()
+                        .description("Refer the Wealthpilot first league GitHub")
+                        .url("https://github.com/vishnuvardhanreddy30/wealthpilot-first-league"));
+    }
+}

--- a/src/main/java/com/task/wealthpilot/firstleague/controller/GameScheduleController.java
+++ b/src/main/java/com/task/wealthpilot/firstleague/controller/GameScheduleController.java
@@ -3,6 +3,9 @@ package com.task.wealthpilot.firstleague.controller;
 import com.task.wealthpilot.firstleague.model.LeagueRequest;
 import com.task.wealthpilot.firstleague.model.LeagueResponse;
 import com.task.wealthpilot.firstleague.service.GameScheduleService;
+import com.task.wealthpilot.firstleague.service.exception.GameScheduleServiceException;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -10,17 +13,33 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * REST Controller for managing game schedules.
+ */
 @RestController
 @RequiredArgsConstructor
 @Slf4j
 @RestControllerAdvice
 @RequestMapping("/api")
+@Tag(name = "Game Schedule", description = "API for generating game schedules")
 public class GameScheduleController {
 
     private final GameScheduleService gameScheduleService;
 
+    /**
+     * POST /generate-schedule : Generate a game schedule for the league.
+     *
+     * This endpoint generates a game schedule based on the list of teams provided in the request body.
+     * The schedule will follow a round-robin format, with all matches taking place on Saturdays.
+     * There will be a 3-week break between the first and second legs.
+     *
+     * @param league the LeagueRequest containing the list of teams.
+     * @return a CompletableFuture with a LeagueResponse containing the generated schedule.
+     * @throws GameScheduleServiceException if there is an error generating the schedule.
+     */
     @PostMapping("/generate-schedule")
     @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "Generate a game schedule", description = "Generates a game schedule based on the list of teams provided")
     public CompletableFuture<LeagueResponse> generateSchedule(@RequestBody LeagueRequest league) {
 
         return CompletableFuture.supplyAsync(() -> gameScheduleService.generateSchedule(league.getTeams()));

--- a/src/main/java/com/task/wealthpilot/firstleague/controller/GameScheduleMultipleMatchesController.java
+++ b/src/main/java/com/task/wealthpilot/firstleague/controller/GameScheduleMultipleMatchesController.java
@@ -3,6 +3,9 @@ package com.task.wealthpilot.firstleague.controller;
 import com.task.wealthpilot.firstleague.model.LeagueRequest;
 import com.task.wealthpilot.firstleague.model.LeagueResponse;
 import com.task.wealthpilot.firstleague.service.GameScheduleMultipleMatchesService;
+import com.task.wealthpilot.firstleague.service.exception.GameScheduleServiceException;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -10,16 +13,32 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * REST Controller for managing game schedules Multiple Matches Per Week.
+ */
 @RestController
 @RequiredArgsConstructor
 @Slf4j
 @RestControllerAdvice
 @RequestMapping("/api")
+@Tag(name = "Game Schedule Multiple Matches Per Week", description = "API for generating game schedules Multiple Matches Per Week")
 public class GameScheduleMultipleMatchesController {
     private final GameScheduleMultipleMatchesService generateScheduleMultipleMatchesPerWeek;
 
+    /**
+     * POST /generate-schedule-multiple : Generate a game schedule Multiple Matches Per Week for the league.
+     *
+     * This endpoint generates a game schedule Multiple Matches Per Week based on the list of teams provided in the request body.
+     * The schedule will follow a round-robin format, with all matches taking place on Saturdays.
+     * There will be a 3-week break between the first and second legs.
+     *
+     * @param league the LeagueRequest containing the list of teams.
+     * @return a CompletableFuture with a LeagueResponse containing the generated schedule.
+     * @throws GameScheduleServiceException if there is an error generating the schedule.
+     */
     @PostMapping("/generate-schedule-multiple")
     @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "Generate a game schedule Multiple Matches Per Week", description = "Generates a game schedule Multiple Matches Per Week based on the list of teams provided")
     public CompletableFuture<LeagueResponse> generateScheduleMultipleMatchesPerWeek(@RequestBody LeagueRequest league) {
         return CompletableFuture.supplyAsync(() -> generateScheduleMultipleMatchesPerWeek.generateScheduleMultipleMatchesPerWeek(league.getTeams()));
     }

--- a/src/main/java/com/task/wealthpilot/firstleague/model/LeagueRequest.java
+++ b/src/main/java/com/task/wealthpilot/firstleague/model/LeagueRequest.java
@@ -6,6 +6,10 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
+
+/**
+ * Request object for generating a game schedule.
+ */
 @NoArgsConstructor
 @AllArgsConstructor
 @Data

--- a/src/main/java/com/task/wealthpilot/firstleague/model/LeagueResponse.java
+++ b/src/main/java/com/task/wealthpilot/firstleague/model/LeagueResponse.java
@@ -7,6 +7,9 @@ import lombok.NoArgsConstructor;
 
 import java.util.List;
 
+/**
+ * Response object containing the generated game schedule.
+ */
 @NoArgsConstructor
 @AllArgsConstructor
 @Data

--- a/src/main/java/com/task/wealthpilot/firstleague/model/Team.java
+++ b/src/main/java/com/task/wealthpilot/firstleague/model/Team.java
@@ -1,8 +1,14 @@
 package com.task.wealthpilot.firstleague.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
+/**
+ * Model representing a team in the league.
+ */
 @NoArgsConstructor
 @AllArgsConstructor
 @Data

--- a/src/main/java/com/task/wealthpilot/firstleague/service/GameScheduleMultipleMatchesService.java
+++ b/src/main/java/com/task/wealthpilot/firstleague/service/GameScheduleMultipleMatchesService.java
@@ -2,9 +2,20 @@ package com.task.wealthpilot.firstleague.service;
 
 import com.task.wealthpilot.firstleague.model.LeagueResponse;
 import com.task.wealthpilot.firstleague.model.Team;
+import com.task.wealthpilot.firstleague.service.exception.GameScheduleServiceException;
 
 import java.util.List;
 
+/**
+ * Service interface for generating game schedules Multiple Matches Per Week.
+ */
 public interface GameScheduleMultipleMatchesService {
+    /**
+     * Generate a game schedule Multiple Matches Per Week for the provided list of teams.
+     *
+     * @param teams the list of teams to include in the schedule.
+     * @return a LeagueResponse containing the generated schedule.
+     * @throws GameScheduleServiceException if there is an error generating the schedule.
+     */
     LeagueResponse generateScheduleMultipleMatchesPerWeek(List<Team> teams);
 }

--- a/src/main/java/com/task/wealthpilot/firstleague/service/GameScheduleService.java
+++ b/src/main/java/com/task/wealthpilot/firstleague/service/GameScheduleService.java
@@ -2,9 +2,20 @@ package com.task.wealthpilot.firstleague.service;
 
 import com.task.wealthpilot.firstleague.model.LeagueResponse;
 import com.task.wealthpilot.firstleague.model.Team;
+import com.task.wealthpilot.firstleague.service.exception.GameScheduleServiceException;
 
 import java.util.List;
 
+/**
+ * Service interface for generating game schedules.
+ */
 public interface GameScheduleService {
+    /**
+     * Generate a game schedule for the provided list of teams.
+     *
+     * @param teams the list of teams to include in the schedule.
+     * @return a LeagueResponse containing the generated schedule.
+     * @throws GameScheduleServiceException if there is an error generating the schedule.
+     */
     LeagueResponse generateSchedule(List<Team> teams);
 }

--- a/src/main/java/com/task/wealthpilot/firstleague/service/impl/GameScheduleMultipleMatchesServiceImpl.java
+++ b/src/main/java/com/task/wealthpilot/firstleague/service/impl/GameScheduleMultipleMatchesServiceImpl.java
@@ -15,6 +15,9 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.util.List;
 
+/**
+ * Implementation of the GameScheduleMultipleMatchesService.
+ */
 @Service
 @RequiredArgsConstructor
 @Slf4j

--- a/src/main/java/com/task/wealthpilot/firstleague/service/impl/GameScheduleServiceImpl.java
+++ b/src/main/java/com/task/wealthpilot/firstleague/service/impl/GameScheduleServiceImpl.java
@@ -15,6 +15,9 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.util.List;
 
+/**
+ * Implementation of the GameScheduleService.
+ */
 @Service
 @RequiredArgsConstructor
 @Slf4j

--- a/src/main/java/com/task/wealthpilot/firstleague/service/mapper/GameScheduleMapper.java
+++ b/src/main/java/com/task/wealthpilot/firstleague/service/mapper/GameScheduleMapper.java
@@ -13,6 +13,9 @@ import java.util.function.IntUnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+/**
+ * Mapper of the GameScheduleService and GameScheduleMultipleMatchesService.
+ */
 @Component
 public class GameScheduleMapper {
     @Value("${league.break.weeks}")
@@ -23,7 +26,7 @@ public class GameScheduleMapper {
 
     private final AtomicInteger index = new AtomicInteger(1);
 
-    public IntUnaryOperator calculateStartDate = (currentIndex) -> {
+    private IntUnaryOperator calculateStartDate = (currentIndex) -> {
         if (currentIndex == league_matches) {
             index.set(1);
             return 1;

--- a/src/main/java/com/task/wealthpilot/firstleague/utils/DateUtil.java
+++ b/src/main/java/com/task/wealthpilot/firstleague/utils/DateUtil.java
@@ -1,5 +1,6 @@
 package com.task.wealthpilot.firstleague.utils;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,3 +3,6 @@ spring.application.name=Wealthpilot-first-league
 league.start.date=2019-10-03
 league.break.weeks=3
 league.matches.per.saturday=2
+
+springdoc.swagger-ui.path=/swagger-ui.html
+springdoc.api-docs.path=/api-docs

--- a/src/test/java/com/task/wealthpilot/firstleague/controller/GameScheduleControllerTest.java
+++ b/src/test/java/com/task/wealthpilot/firstleague/controller/GameScheduleControllerTest.java
@@ -55,4 +55,13 @@ public class GameScheduleControllerTest {
                 ))
                 .build();
     }
+
+    @Test
+    public void generateScheduleTest_Exception() throws Exception {
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/generate-schedule")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(leagueRequest()))
+        ).andExpect(status().isCreated());
+    }
 }


### PR DESCRIPTION
- Add springdoc-openapi-ui and api dependency for OpenAPI/Swagger integration
- Create OpenApiConfig class for OpenAPI customization
  - Configure API title, description, version, contact, and license information
- Annotate GameScheduleController and GameScheduleMultipleMatchesController with OpenAPI annotations
  - Provide summary and description for API endpoints
- Ensure interactive API documentation is available at /swagger-ui.html
- Update application properties for proper documentation display